### PR TITLE
Allow install when PHP > 7.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dopamedia/module-message-queue",
   "description": "N/A",
   "require": {
-    "php": "7.0.2|7.0.4|~7.0.6"
+    "php": "^7.0"
   },
   "type": "magento2-module",
   "version": "1.0.0",


### PR DESCRIPTION
Bug fix: cannot install when PHP > 7.0.x